### PR TITLE
Remove default arguments in private method that aren't used

### DIFF
--- a/lib/closex/http_client.ex
+++ b/lib/closex/http_client.ex
@@ -85,7 +85,7 @@ defmodule Closex.HTTPClient do
 
   # Private stuff...
 
-  defp find(resource, search_term, opts \\ []) do
+  defp find(resource, search_term, opts) do
     opts = merge_search_term_into_opts(search_term, opts)
 
     get("/#{resource}/", [], opts)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Closex.Mixfile do
   def project do
     [
       app: :closex,
-      version: "0.5.12",
+      version: "0.5.13",
       build_path: "_build",
       config_path: "config/config.exs",
       deps_path: "deps",


### PR DESCRIPTION
This was causing the following compilation warning, but is ultimately
fine because we always pass options into this function. If we create a
case in the future that doesn't, we can add this default back in then.

    $ mix compile
    Compiling 6 files (.ex)
    warning: default arguments in find/3 are never used
      lib/closex/http_client.ex:88