### PR TITLE
Respect rate limits and retry once on find actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,16 @@ In your config.exs:
 
 ```elixir
 config :closex,
-  api_key: "YOUR_API_KEY"
+  # This should be accessible from your user's account page in close.io
+  api_key: "YOUR_API_KEY",
+
+  # This is a beta feature which will wait and retry `find_lead` and
+  # `find_opportunity` requests *once* if you hit your rate limit. The intention
+  # is that this will be gradually rolled out across other requests as needed.
+  rate_limit_retry: true # Defaults to `false` (don't retry)
 ```
 
-You can also read from an environment variable:
+You can also read the API key from an environment variable, such as:
 
 ```elixir
 config :closex,
@@ -86,7 +92,7 @@ Next, use it in your code:
 # your_app/lib/module_which_uses_closeio.ex
 
 defmodule YourApp.ModuleWhichUsesCloseIO do
-  
+
   @closeio_client Application.fetch_env!(:your_app, :closeio_client)
 
   def do_things_with_a_close_io_lead(id) do
@@ -109,7 +115,6 @@ config :yourapp,
   closeio_client: Closex.MockClient,
   ...other configuration...
 ```
-
 
 For more details on the mock client please see [the docs](https://hexdocs.pm/closex).
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,21 @@ Options will be passed through to [HTTPoison](https://github.com/edgurgel/httpoi
 Closex.HTTPClient.get_lead("my_lead_id", timeout: 500, recv_timeout: 1_000)
 ```
 
+### Rate limit retry
+
+When we hit a rate limit on certain requests, there's a beta configuration to get the client to take this into account, wait a second longer than the remaining rate limit window then retry again. This can be enabled for all affected requests (see [Configuration](#configuration)) or on a per-request basis:
+
+```elixir
+Closex.HTTPClient.get_lead("my_lead_id", rate_limit_retry: true)
+```
+
+This is only limited to certain requests as it's being trialled, if useful then we'll roll it out across other requests. The requests are:
+
+* `find_leads`
+* `find_opportunities`
+* `find_all_opportunities`
+* `get_users`
+
 ## Contributing
 
 Everyone is encouraged to help improve this project. Here are a few ways you can help:

--- a/config/config.exs
+++ b/config/config.exs
@@ -6,7 +6,8 @@ if Mix.env() == :test do
   config :closex,
     api_key: System.get_env("CLOSEX_CLOSEIO_API_KEY") || "FAKE_CLOSEIO_TOKEN",
     fallback_client: Closex.MockClient,
-    mock_client_fixtures_dir: "test/fixtures"
+    mock_client_fixtures_dir: "test/fixtures",
+    sleep_module: Closex.SleepMock
 
   config :logger, level: :warn
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,7 +7,6 @@ if Mix.env() == :test do
     api_key: System.get_env("CLOSEX_CLOSEIO_API_KEY") || "FAKE_CLOSEIO_TOKEN",
     fallback_client: Closex.MockClient,
     mock_client_fixtures_dir: "test/fixtures",
-    rate_limit_retry: true,
     sleep_module: Closex.SleepMock
 
   config :logger, level: :warn

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,6 +7,7 @@ if Mix.env() == :test do
     api_key: System.get_env("CLOSEX_CLOSEIO_API_KEY") || "FAKE_CLOSEIO_TOKEN",
     fallback_client: Closex.MockClient,
     mock_client_fixtures_dir: "test/fixtures",
+    rate_limit_retry: true,
     sleep_module: Closex.SleepMock
 
   config :logger, level: :warn

--- a/lib/closex/http_client.ex
+++ b/lib/closex/http_client.ex
@@ -9,6 +9,7 @@ defmodule Closex.HTTPClient do
 
   @base_url "https://app.close.io/api/v1"
   @behaviour Closex.ClientBehaviour
+  @sleep_module Application.get_env(:closex, :sleep_module, Process)
 
   ## TODO: httpoison opts should move underneath the `:httpoison` key
 
@@ -119,7 +120,7 @@ defmodule Closex.HTTPClient do
   defp wait_and_retry(resource, opts, rate_reset) do
     {seconds, _remainder} = Integer.parse(rate_reset)
 
-    if Mix.env() != :test, do: Process.sleep(:timer.seconds(seconds + 1))
+    @sleep_module.sleep(:timer.seconds(seconds + 1))
 
     # REVIEW: This is purely for tests, is that a smell? Any alternatives?
     send(self(), {:retry_find, [seconds + 1]})

--- a/lib/closex/http_client.ex
+++ b/lib/closex/http_client.ex
@@ -10,7 +10,6 @@ defmodule Closex.HTTPClient do
   @base_url "https://app.close.io/api/v1"
   @behaviour Closex.ClientBehaviour
   @sleep_module Application.get_env(:closex, :sleep_module, Process)
-  @rate_limit_retry Application.get_env(:closex, :rate_limit_retry, false)
 
   ## TODO: httpoison opts should move underneath the `:httpoison` key
 
@@ -94,7 +93,7 @@ defmodule Closex.HTTPClient do
   defp find(resource, search_term, opts) do
     opts = merge_search_term_into_opts(search_term, opts)
 
-    if @rate_limit_retry do
+    if rate_limit_retry?(opts) do
       find_respecting_rate_limit(resource, opts)
     else
       make_find_request(resource, opts)
@@ -248,5 +247,13 @@ defmodule Closex.HTTPClient do
       {:system, env} -> System.get_env(env)
       key when is_binary(key) -> key
     end
+  end
+
+  defp rate_limit_retry?(opts) do
+    Keyword.get(
+      opts,
+      :rate_limit_retry,
+      Application.get_env(:closex, :rate_limit_retry, false)
+    )
   end
 end

--- a/lib/closex/http_client.ex
+++ b/lib/closex/http_client.ex
@@ -122,9 +122,6 @@ defmodule Closex.HTTPClient do
 
     @sleep_module.sleep(:timer.seconds(seconds + 1))
 
-    # REVIEW: This is purely for tests, is that a smell? Any alternatives?
-    send(self(), {:retry_find, [seconds + 1]})
-
     find(resource, opts)
   end
 

--- a/test/fixtures/vcr_cassettes/find_leads_rate_limit.json
+++ b/test/fixtures/vcr_cassettes/find_leads_rate_limit.json
@@ -1,0 +1,72 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "Accept": "application/json"
+      },
+      "method": "get",
+      "options": {
+        "basic_auth": [
+          "FAKE_CLOSEIO_TOKEN",
+          ""
+        ]
+      },
+      "request_body": "",
+      "url": "https://app.close.io/api/v1/lead/?query=Minogue+OR+Princess"
+    },
+    "response": {
+      "body": "{\"message\": \"API call count exceeded for this period\", \"rate_endpoint_group\": \"ab60a2938ea23638a0c6f32222cadc8e\", \"rate_limit\": 320, \"rate_limit_type\": \"key\", \"rate_reset\": \"0.595956\", \"rate_window\": 8}",
+      "headers": {
+        "Content-Type": "application/json",
+        "Date": "Fri, 29 Sep 2017 11:01:40 GMT",
+        "Set-Cookie": "session=; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Path=/",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Vary": "Accept",
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-Rate-Limit-Limit": "320",
+        "X-Rate-Limit-Remaining": "0",
+        "X-Rate-Limit-Reset": "0.595956",
+        "Content-Length": "3726",
+        "Connection": "keep-alive"
+      },
+      "status_code": 429,
+      "type": "ok"
+    }
+  },
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "Accept": "application/json"
+      },
+      "method": "get",
+      "options": {
+        "basic_auth": [
+          "FAKE_CLOSEIO_TOKEN",
+          ""
+        ]
+      },
+      "request_body": "",
+      "url": "https://app.close.io/api/v1/lead/?query=FOO"
+    },
+    "response": {
+      "body": "{\"has_more\": false, \"total_results\": 2, \"data\": [{\"tasks\": [], \"custom.lcf_YJ3m3sm73KDJ9amJMLYYO8ox25c325flyWrDP7Nm8oo\": \"12345\", \"addresses\": [], \"date_updated\": \"2017-09-27T10:44:27.875000+00:00\", \"created_by_name\": \"API User (DO NOT DELETE)\", \"opportunities\": [{\"date_updated\": \"2017-09-18T14:31:04.685000+00:00\", \"created_by_name\": \"API User (DO NOT DELETE)\", \"value_currency\": \"USD\", \"contact_id\": null, \"lead_name\": \"Wiley Minogue\", \"contact_name\": null, \"id\": \"oppo_WcJwIYBJWzY6wJhXVcoiGCMvDjHoy6tX5BYwhuYy5hN\", \"confidence\": 100, \"user_id\": \"user_CwSfS8J6DsD6tnAsUwNFKCpS7Tq9LVCgJvHapOcpWyW\", \"value_period\": \"one_time\", \"created_by\": \"user_CwSfS8J6DsD6tnAsUwNFKCpS7Tq9LVCgJvHapOcpWyW\", \"note\": \"\", \"updated_by_name\": \"API User (DO NOT DELETE)\", \"user_name\": \"API User (DO NOT DELETE)\", \"status_type\": \"won\", \"updated_by\": \"user_CwSfS8J6DsD6tnAsUwNFKCpS7Tq9LVCgJvHapOcpWyW\", \"status_id\": \"stat_MBQNyevXlkrXlo8NKULnG8wTW7nJOyblaGeoI1VxZrW\", \"value_formatted\": \"$1,000,000\", \"organization_id\": \"orga_CC25dsMNG4KsRpxn2LEwPUVyGRs4poLYFIBsioIK4Oj\", \"integration_links\": [], \"date_won\": \"2017-09-18\", \"lead_id\": \"lead_XLnuBerozWCpobHZOJjbC9KpPIUcFgpDfut809pCcp9\", \"date_lost\": null, \"value\": 100000000, \"status_label\": \"Won\", \"date_created\": \"2017-09-18T12:43:26.315000+00:00\"}], \"id\": \"lead_XLnuBerozWCpobHZOJjbC9KpPIUcFgpDfut809pCcp9\", \"description\": \"\", \"display_name\": \"Wiley Minogue\", \"contacts\": [], \"created_by\": \"user_CwSfS8J6DsD6tnAsUwNFKCpS7Tq9LVCgJvHapOcpWyW\", \"custom\": {\"Source\": \"Google\", \"Deal ID\": \"12345\"}, \"updated_by_name\": \"API User (DO NOT DELETE)\", \"updated_by\": \"user_CwSfS8J6DsD6tnAsUwNFKCpS7Tq9LVCgJvHapOcpWyW\", \"status_id\": \"stat_dzhTAsvOFDm6CbgRQkPjdjAeO6B8lFCeZcuDwN2yjFd\", \"html_url\": \"https://app.close.io/lead/lead_XLnuBerozWCpobHZOJjbC9KpPIUcFgpDfut809pCcp9/\", \"organization_id\": \"orga_CC25dsMNG4KsRpxn2LEwPUVyGRs4poLYFIBsioIK4Oj\", \"integration_links\": [], \"custom.lcf_Ptp5X0aY5GMDbTzkhma1YeS7JAA0atxeaap21HhJnYa\": \"Google\", \"name\": \"Wiley Minogue\", \"url\": null, \"status_label\": \"Potential\", \"date_created\": \"2017-07-24T09:33:50.766000+00:00\"}, {\"tasks\": [], \"custom.lcf_YJ3m3sm73KDJ9amJMLYYO8ox25c325flyWrDP7Nm8oo\": \"12\", \"addresses\": [], \"date_updated\": \"2017-07-25T11:03:46.484000+00:00\", \"created_by_name\": \"API User (DO NOT DELETE)\", \"opportunities\": [], \"id\": \"lead_m006WNwjoRLYJE1P698N6x2DdR5V8fZOIUf832SrI9N\", \"description\": \"\", \"display_name\": \"Princess\", \"custom.lcf_IJF7S7rCDvURDQAwdOBtWsVaMdE22HdW4Nz6A7dWMeR\": \"http://www.rightmove.co.uk/property-for-sale/millenium-falcon.html\", \"contacts\": [], \"created_by\": \"user_CwSfS8J6DsD6tnAsUwNFKCpS7Tq9LVCgJvHapOcpWyW\", \"custom\": {\"Mixpanel ID\": \"FAKE_MIXPANELID\", \"03. Property Details\": \"3 beds, S\", \"04. Listing\": \"http://www.rightmove.co.uk/property-for-sale/millenium-falcon.html\", \"Deal ID\": \"12\", \"02. Address\": \"1 Millenium Falcon\", \"Google Analytics ID\": \"FAKE_GAID\", \"Offer ID\": \"2\"}, \"updated_by_name\": \"API User (DO NOT DELETE)\", \"custom.lcf_RKxL7ypo8Nrqrf5mBX5XQT1502TCIuQXEb2p0w4QvoV\": \"FAKE_GAID\", \"custom.lcf_lAfIkfmlUOacvFGHN79b1QtTPCldkXmIMYyHDwm8ByU\": \"1 Millenium Falcon\", \"custom.lcf_Sr9rVrGnpmRGSS5tSPSqYNcVVIh1JsSU26U30oE6b7y\": \"FAKE_MIXPANELID\", \"custom.lcf_uisJjG9EUCD8WpsmEPNFQw6gpB8cxlrf6QEGrmcsqbn\": \"2\", \"updated_by\": \"user_CwSfS8J6DsD6tnAsUwNFKCpS7Tq9LVCgJvHapOcpWyW\", \"status_id\": \"stat_dzhTAsvOFDm6CbgRQkPjdjAeO6B8lFCeZcuDwN2yjFd\", \"html_url\": \"https://app.close.io/lead/lead_m006WNwjoRLYJE1P698N6x2DdR5V8fZOIUf832SrI9N/\", \"organization_id\": \"orga_CC25dsMNG4KsRpxn2LEwPUVyGRs4poLYFIBsioIK4Oj\", \"integration_links\": [], \"name\": \"Princess\", \"url\": null, \"status_label\": \"Potential\", \"custom.lcf_4oEyhiUJipz4oiv1zJnmLVETcjLJjsqE1zJEF0Kcr8A\": \"3 beds, S\", \"date_created\": \"2017-07-24T09:34:12.687000+00:00\"}]}",
+      "headers": {
+        "Content-Type": "application/json",
+        "Date": "Fri, 29 Sep 2017 11:01:40 GMT",
+        "Set-Cookie": "session=; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Path=/",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Vary": "Accept",
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-Rate-Limit-Limit": "600",
+        "X-Rate-Limit-Remaining": "599",
+        "X-Rate-Limit-Reset": "14.260394",
+        "Content-Length": "3726",
+        "Connection": "keep-alive"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/http_client_test.exs
+++ b/test/http_client_test.exs
@@ -356,7 +356,7 @@ defmodule Closex.HTTPClientTest do
 
     test "obeys rate limits, waiting once" do
       use_cassette "find_leads_rate_limit" do
-        {:ok, result} = find_leads("Minogue OR Princess")
+        {:ok, result} = find_leads("Minogue OR Princess", rate_limit_retry: true)
 
         assert_received {:sleep_mock, [1000]}
 
@@ -369,6 +369,19 @@ defmodule Closex.HTTPClientTest do
           end
 
         assert lead_names == ["Wiley Minogue", "Princess"]
+      end
+    end
+
+    test "returns rate limit failures if not configured" do
+      use_cassette "find_leads_rate_limit" do
+        {:error, result} = find_leads("Minogue OR Princess", rate_limit_retry: false)
+
+        refute_received {:sleep_mock, [1000]}
+
+        assert %{
+                 status_code: 429,
+                 body: %{"message" => "API call count exceeded for this period"}
+               } = result
       end
     end
   end

--- a/test/http_client_test.exs
+++ b/test/http_client_test.exs
@@ -353,6 +353,24 @@ defmodule Closex.HTTPClientTest do
         assert leads == []
       end
     end
+
+    test "obeys rate limits, waiting once" do
+      use_cassette "find_leads_rate_limit" do
+        {:ok, result} = find_leads("Minogue OR Princess")
+
+        assert_received {:retry_find, [1]}
+
+        assert %{"has_more" => false, "total_results" => 2, "data" => leads} = result
+        assert is_list(leads)
+
+        lead_names =
+          for %{"name" => name} <- leads do
+            name
+          end
+
+        assert lead_names == ["Wiley Minogue", "Princess"]
+      end
+    end
   end
 
   describe "find_opportunities/1" do

--- a/test/http_client_test.exs
+++ b/test/http_client_test.exs
@@ -358,7 +358,7 @@ defmodule Closex.HTTPClientTest do
       use_cassette "find_leads_rate_limit" do
         {:ok, result} = find_leads("Minogue OR Princess")
 
-        assert_received {:retry_find, [1]}
+        assert_received {:sleep_mock, [1000]}
 
         assert %{"has_more" => false, "total_results" => 2, "data" => leads} = result
         assert is_list(leads)

--- a/test/support/sleep_mock.ex
+++ b/test/support/sleep_mock.ex
@@ -5,5 +5,5 @@ defmodule Closex.SleepMock do
   (for example) pass
   """
 
-  def sleep(_arg), do: nil
+  def sleep(zzz), do: send(self(), {:sleep_mock, [zzz]})
 end

--- a/test/support/sleep_mock.ex
+++ b/test/support/sleep_mock.ex
@@ -1,0 +1,9 @@
+defmodule Closex.SleepMock do
+  @moduledoc """
+  This is purely for testing purposes to stub out actually sleeping when
+  retrying requests; in production we pause to let rate limit windows
+  (for example) pass
+  """
+
+  def sleep(_arg), do: nil
+end


### PR DESCRIPTION
We're hitting rate limits on (specifically) `find` operations,
triggering a sentry here: https://sentry.io/nested/elixir/issues/563686900/

This inspects and respsects the rate limit information we get back from
Close.io. If we hit a rate limit we will:

1. Inspect the `rate_reset` window (time until the window resets)
2. Wait for 1 second more than the window specifies
3. Retry once

We only retry once because if we're spamming their API, we probably
don't want to spam indefinitely if we continually hit rate limits. We
also want to get an alert telling us this is the case