### PR TITLE
Allows a user to specify a path for a mock response when querying for a lead

### DIFF
--- a/lib/closex/mock_client/mock_client.ex
+++ b/lib/closex/mock_client/mock_client.ex
@@ -85,8 +85,13 @@ defmodule Closex.MockClient do
 
   def get_lead(id, opts) do
     lead =
-      load("lead.json")
-      |> Map.put("id", id)
+      if Enum.member?(opts, :path) do
+        load(opts.path)
+        |> Map.put("id", id)
+      else
+        load("lead.json")
+        |> Map.put("id", id)
+      end
 
     send(self(), {:closex_mock_client, :get_lead, [id, opts]})
     {:ok, lead}


### PR DESCRIPTION
This will allow me to do something like this:

```elixir
  def get_lead(lead_id, opts \\ []) do
    Core.SpandexTracer.span @span_opts do
      with {:ok, payload} <- closex_client().get_lead(lead_id, opts) do
        {:ok, Lead.from_closeio(payload)}
      end
    end
  end
```
Then

```elixir
Client.get_lead("10", path: "no_rm_lead.json")
```

That makes it easier for me to specify the json that I want as a response from the mock client.

