### PR TITLE
Pass through errors in get_users method

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Closex.Mixfile do
   def project do
     [
       app: :closex,
-      version: "1.0.3",
+      version: "1.0.4",
       build_path: "_build",
       config_path: "config/config.exs",
       deps_path: "deps",

--- a/test/fixtures/vcr_cassettes/get_users.json
+++ b/test/fixtures/vcr_cassettes/get_users.json
@@ -8,7 +8,7 @@
       "method": "get",
       "options": {
         "basic_auth": [
-          "4a20342eb258aefd0a9805b44600fa0b60cc0d1d089e65064e38d41d",
+          "FAKE_CLOSEIO_TOKEN",
           ""
         ]
       },

--- a/test/fixtures/vcr_cassettes/get_users_timeout.json
+++ b/test/fixtures/vcr_cassettes/get_users_timeout.json
@@ -1,0 +1,25 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "Accept": "application/json"
+      },
+      "method": "get",
+      "options": {
+        "basic_auth": [
+          "FAKE_CLOSEIO_TOKEN",
+          ""
+        ]
+      },
+      "request_body": "",
+      "url": "https://app.close.io/api/v1/user/?_limit=100&_skip=0&query="
+    },
+    "response": {
+      "body": "fake_timeout",
+      "headers": [],
+      "status_code": null,
+      "type": "error"
+    }
+  }
+]

--- a/test/http_client_test.exs
+++ b/test/http_client_test.exs
@@ -593,6 +593,12 @@ defmodule Closex.HTTPClientTest do
         assert first_user["last_name"] == "Margolius"
       end
     end
+
+    test "if close.io times out, it acts as a pass through" do
+      use_cassette "get_users_timeout", match_requests_on: [:request_body, :query] do
+        {:error, %{reason: "fake_timeout"}} = get_users()
+      end
+    end
   end
 
   describe ".get_organization/1" do


### PR DESCRIPTION
If we get a timeout or other error, pass through to the Module which
called us so it can handle it.