### PR TITLE
Fix matcherror on some close.io validation failures

### DIFF
--- a/lib/closex/http_client.ex
+++ b/lib/closex/http_client.ex
@@ -180,7 +180,7 @@ defmodule Closex.HTTPClient do
          {:ok,
           %{
             status_code: 400,
-            body: reason = %{"errors" => _errors, "field-errors" => _field_errors}
+            body: reason
           }}
        ) do
     {:error, reason}


### PR DESCRIPTION
Close.io is not consistent (it sometimes returns "field-errors" without
"errors") so it's safest not to match on these keys at all.