### PR TITLE
Adds command for searching phone numbers

### DIFF
--- a/lib/closex/client_behaviour.ex
+++ b/lib/closex/client_behaviour.ex
@@ -33,4 +33,5 @@ defmodule Closex.ClientBehaviour do
   @callback update_contact(id, map, opts) :: result
   @callback merge_leads(id, id) :: result
   @callback log_call(map, opts) :: result
+  @callback find_phone_numbers(String.t(), opts) :: result
 end

--- a/lib/closex/http_client.ex
+++ b/lib/closex/http_client.ex
@@ -141,6 +141,15 @@ defmodule Closex.HTTPClient do
     |> handle_response
   end
 
+  @doc "list or search for phone numbers:
+  https://developer.close.io/#phone-numbers"
+  @impl true
+  def find_phone_numbers(search_term, opts \\ []) do
+    # We call make_find_request directly because the search term IS the query string for this request
+    # i.e. ?number=1234 and not ?query="number=1234"
+    make_find_request("phone_number/?#{search_term}", opts)
+  end
+
   # Private stuff...
 
   defp find(resource, search_term, opts) do

--- a/test/fixtures/vcr_cassettes/find_phone_numbers.json
+++ b/test/fixtures/vcr_cassettes/find_phone_numbers.json
@@ -1,0 +1,36 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "Content-Type": "application/json",
+        "Accept": "application/json"
+      },
+      "method": "get",
+      "options": {
+        "basic_auth": ["FAKE_CLOSEIO_TOKEN", ""]
+      },
+      "request_body": "",
+      "url": "https://app.close.io/api/v1/phone_number/?number=+442039742049/"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"has_more\": false, \"data\": [{\"voicemail_greeting_url\": null, \"date_updated\": \"2018-12-13T20:20:18.293000+00:00\", \"sms_enabled\": false, \"number\": \"+442039742049\", \"type\": \"virtual\", \"id\": \"phon_OrDCuHzMuqg3nAyBvmSUxlTWpA9Hu4vRlkeQDHvEhvI\", \"phone_numbers\": [], \"forward_to_enabled\": false, \"user_id\": null, \"number_formatted\": \"+44 20 3974 2049\", \"label\": \"BYOC\", \"participants\": [\"user_CwSfS8J6DsD6tnAsUwNFKCpS7Tq9LVCgJvHapOcpWyW\", \"user_P7CxiTgnGfZBOar8XeKFiRbzCY4LMiDSvGloZ4bpMw9\", \"user_RdF8Nj9NBNX110aFSbn5JuZu8IoowiLnJzVxs3kyZsY\", \"user_lz47i62pmeQA4gFDthrDryLBNcMTrO2xkGQGR6hsIQG\"], \"is_group_number\": true, \"is_verified\": false, \"press_1_to_accept\": false, \"forward_to_formatted\": null, \"organization_id\": \"orga_CC25dsMNG4KsRpxn2LEwPUVyGRs4poLYFIBsioIK4Oj\", \"forward_to\": \"\", \"phone_numbers_formatted\": [], \"carrier\": \"plivo\", \"date_created\": \"2018-09-08T03:48:40.401000+00:00\"}]}",
+      "headers": {
+        "Content-Type": "application/json",
+        "Date": "Thu, 10 Jan 2019 11:30:45 GMT",
+        "Set-Cookie": "session=; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Path=/",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Vary": "Accept",
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-Rate-Limit-Limit": "320",
+        "X-Rate-Limit-Remaining": "319",
+        "X-Rate-Limit-Reset": "7.347352",
+        "Content-Length": "888",
+        "Connection": "keep-alive"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixtures/vcr_cassettes/find_phone_numbers_empty.json
+++ b/test/fixtures/vcr_cassettes/find_phone_numbers_empty.json
@@ -1,0 +1,36 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "Content-Type": "application/json",
+        "Accept": "application/json"
+      },
+      "method": "get",
+      "options": {
+        "basic_auth": ["FAKE_CLOSEIO_TOKEN", ""]
+      },
+      "request_body": "",
+      "url": "https://app.close.io/api/v1/phone_number/?number=thisshouldneverexist/"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"has_more\": false, \"data\": []}",
+      "headers": {
+        "Content-Type": "application/json",
+        "Date": "Thu, 10 Jan 2019 11:32:43 GMT",
+        "Set-Cookie": "session=; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Path=/",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Vary": "Accept",
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-Rate-Limit-Limit": "320",
+        "X-Rate-Limit-Remaining": "319",
+        "X-Rate-Limit-Reset": "7.081515",
+        "Content-Length": "31",
+        "Connection": "keep-alive"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/http_client_test.exs
+++ b/test/http_client_test.exs
@@ -928,4 +928,30 @@ defmodule Closex.HTTPClientTest do
       end
     end
   end
+
+  describe "find_phone_numbers/1" do
+    test "if some phone_numbers are found, it returns a list of phone_numbers" do
+      search_term = "number=+442039742049"
+
+      use_cassette "find_phone_numbers", match_requests_on: [:request_body, :query] do
+        {:ok, result} = find_phone_numbers(search_term)
+        assert %{"data" => phone_numbers, "has_more" => false} = result
+        assert is_list(phone_numbers)
+        assert Enum.count(phone_numbers) == 1
+        user = hd(phone_numbers)
+        assert user["number"] == "+442039742049"
+      end
+    end
+
+    test "if no phone_numbers are found, it returns an empty list" do
+      search_term = "number=thisshouldneverexist"
+
+      use_cassette "find_phone_numbers_empty", match_requests_on: [:request_body, :query] do
+        {:ok, result} = find_phone_numbers(search_term)
+        assert %{"has_more" => false, "data" => phone_numbers} = result
+        assert is_list(phone_numbers)
+        assert phone_numbers == []
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adding a wrapper for the `GET /phone_number` CloseIO api call.

This is needed to find the userId of the dialler we should log the call against when logging calls manually from rested (softphone integration)